### PR TITLE
feat: expand date filter options

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -25,7 +25,18 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 	});
 
-	// Todos fechados por padrão
-	document.querySelectorAll('.accordion-content').forEach(c => c.classList.remove('open'));
-	document.querySelectorAll('.accordion-header').forEach(h => h.classList.remove('active'));
+        // Todos fechados por padrão
+        document.querySelectorAll('.accordion-content').forEach(c => c.classList.remove('open'));
+        document.querySelectorAll('.accordion-header').forEach(h => h.classList.remove('active'));
+
+        // Exibe campos de data personalizada quando necessário
+        const dateFilter = document.getElementById('dateFilter');
+        const customDateRange = document.getElementById('customDateRange');
+        if (dateFilter && customDateRange) {
+                const toggleCustomRange = () => {
+                        customDateRange.style.display = (dateFilter.value === 'custom') ? 'flex' : 'none';
+                };
+                toggleCustomRange();
+                dateFilter.addEventListener('change', toggleCustomRange);
+        }
 });

--- a/static/styles.css
+++ b/static/styles.css
@@ -365,19 +365,24 @@ body {
 	display: block;
 }
 .filter-select, .date-input {
-	width: 100%;
-	padding: 12px 15px;
-	background-color: #2c3e50;
-	border: 2px solid #3498db;
-	border-radius: 8px;
-	color: #ffffff;
-	font-size: 1.2rem;
-	cursor: pointer;
-	transition: all 0.3s ease;
-	margin-bottom: 10px;
+        width: 100%;
+        padding: 12px 15px;
+        background-color: #2c3e50;
+        border: 2px solid #3498db;
+        border-radius: 8px;
+        color: #ffffff;
+        font-size: 1.2rem;
+        cursor: pointer;
+        transition: all 0.3s ease;
+        margin-bottom: 10px;
+}
+.custom-date-range {
+        display: none;
+        flex-direction: column;
+        gap: 10px;
 }
 .checkbox-group, .radio-group {
-	display: flex;
+        display: flex;
 	flex-direction: column;
 	gap: 15px;
 }

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -41,19 +41,27 @@
 				<div class="accordion-item">
 					<button class="accordion-header" type="button">Data</button>
 					<div class="accordion-content">
-						<select id="dateFilter" class="filter-select">
-							<option value="year" selected>Ano Inteiro</option>
-							<option value="month">Último Mês</option>
-							<option value="week">Última Semana</option>
-							<option value="custom">Personalizado</option>
-						</select>
-						<div id="customDateRange" class="custom-date-range" style="display: none;">
-							<input type="date" id="startDate" class="date-input">
-							<input type="date" id="endDate" class="date-input">
-						</div>
-					</div>
-				</div>
-				<div class="accordion-item">
+                                                <select id="dateFilter" class="filter-select">
+                                                        <option value="today" selected>Hoje</option>
+                                                        <option value="yesterday">Ontem</option>
+                                                        <option value="last3">Últimos 3 Dias</option>
+                                                        <option value="last7">Últimos 7 Dias</option>
+                                                        <option value="last30">Últimos 30 Dias</option>
+                                                        <option value="currentWeek">Semana Atual</option>
+                                                        <option value="previousWeek">Semana Anterior</option>
+                                                        <option value="currentMonth">Mês Atual</option>
+                                                        <option value="previousMonth">Mês Anterior</option>
+                                                        <option value="currentYear">Ano Atual</option>
+                                                        <option value="previousYear">Ano Anterior</option>
+                                                        <option value="custom">Personalizado</option>
+                                                </select>
+                                                <div id="customDateRange" class="custom-date-range">
+                                                        <input type="date" id="startDate" class="date-input">
+                                                        <input type="date" id="endDate" class="date-input">
+                                                </div>
+                                        </div>
+                                </div>
+                                <div class="accordion-item">
 					<button class="accordion-header" type="button">Células</button>
 					<div class="accordion-content">
 						<div class="checkbox-group">


### PR DESCRIPTION
## Summary
- expand date filter dropdown with common range options
- toggle custom date range inputs with JavaScript
- style custom date range container

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a3d12d46c48324886e6fd415f691f8