### PR TITLE
Ensure tables fit on any screen

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -812,3 +812,22 @@ button.accordion-header:active {
     margin-top: -2px;
     line-height: 1;
 }
+
+/* Responsive tables */
+.table-container {
+    width: 100%;
+    overflow-x: auto;
+}
+
+table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+@media (max-width: 600px) {
+    table th,
+    table td {
+        font-size: 0.9rem;
+        word-break: break-word;
+    }
+}

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -3,7 +3,7 @@
 <html lang="pt-BR">
 <head>
 	<meta charset="UTF-8">
-	<meta name="viewport" content="width=1920, initial-scale=1.0">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Dashboard CEP</title>
 	<link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 	<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- make dashboard responsive to device width
- add global styles so tables remain readable on small screens

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'app')

------
https://chatgpt.com/codex/tasks/task_e_68a3d0a43f0083248f81d616a7f90251