### PR TITLE
Ensure tables fit on any screen

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -25,7 +25,17 @@ document.addEventListener('DOMContentLoaded', () => {
 		});
 	});
 
-	// Todos fechados por padrão
-	document.querySelectorAll('.accordion-content').forEach(c => c.classList.remove('open'));
-	document.querySelectorAll('.accordion-header').forEach(h => h.classList.remove('active'));
+        // Todos fechados por padrão
+        document.querySelectorAll('.accordion-content').forEach(c => c.classList.remove('open'));
+        document.querySelectorAll('.accordion-header').forEach(h => h.classList.remove('active'));
+
+        // Garante que todas as tabelas fiquem em um contêiner responsivo
+        document.querySelectorAll('table').forEach(table => {
+                if (!table.parentElement.classList.contains('table-container')) {
+                        const wrapper = document.createElement('div');
+                        wrapper.classList.add('table-container');
+                        table.parentNode.insertBefore(wrapper, table);
+                        wrapper.appendChild(table);
+                }
+        });
 });

--- a/static/styles.css
+++ b/static/styles.css
@@ -812,3 +812,29 @@ button.accordion-header:active {
     margin-top: -2px;
     line-height: 1;
 }
+
+/* Responsive tables */
+.table-container {
+    width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
+.table-container table {
+    width: 100%;
+    border-collapse: collapse;
+}
+
+.table-container th,
+.table-container td {
+    padding: 8px;
+    text-align: left;
+}
+
+@media (max-width: 600px) {
+    .table-container th,
+    .table-container td {
+        font-size: 0.9rem;
+        word-break: break-word;
+    }
+}

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -3,7 +3,7 @@
 <html lang="pt-BR">
 <head>
 	<meta charset="UTF-8">
-	<meta name="viewport" content="width=1920, initial-scale=1.0">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
 	<title>Dashboard CEP</title>
 	<link rel="stylesheet" href="{{ url_for('static', filename='styles.css') }}">
 	<script src="https://cdn.jsdelivr.net/npm/chart.js"></script>


### PR DESCRIPTION
## Summary
- wrap all tables in a responsive container on page load so formatting persists on refresh
- refine table styles for consistent padding and mobile scrolling

## Testing
- `pytest` (fails: ModuleNotFoundError: No module named 'app')


------
https://chatgpt.com/codex/tasks/task_e_68a3d0a43f0083248f81d616a7f90251