### PR TITLE
Refine sidebar icons and filter text styling

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -157,6 +157,7 @@ body {
   padding: 0 12px 24px;
   overflow-y: auto;
   transition: width .3s;
+  position: relative;
 }
 
 .sidebar.minimized {
@@ -166,7 +167,6 @@ body {
 
 /* Esconde todos os textos e controles da sidebar quando minimizada */
 .sidebar.minimized .sidebar-title,
-.sidebar.minimized .sidebar-nav-btn,
 .sidebar.minimized .accordion-header,
 .sidebar.minimized .accordion-content,
 .sidebar.minimized .checkbox-label,
@@ -194,10 +194,11 @@ body {
   background: transparent;
   color: var(--yellow);
   cursor: pointer;
-  position: absolute;
+  position: fixed;
+  left: 10px;
   top: 50%;
   transform: translateY(-50%);
-  z-index: 2;
+  z-index: 1000;
 }
 
 .hamburger-bar {
@@ -206,6 +207,30 @@ body {
   background: #3498db;
   border-radius: 2px;
   margin: 3px 0;
+}
+
+.sidebar-nav-btn {
+  position: absolute;
+  right: -22px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+
+.nav-arrow {
+  border: solid #3498db;
+  border-width: 0 4px 4px 0;
+  display: inline-block;
+  padding: 6px;
+  transform: rotate(45deg);
+}
+
+.sidebar-nav-btn.up .nav-arrow {
+  transform: rotate(-135deg);
 }
 
 .sidebar-title {
@@ -266,6 +291,7 @@ body {
   align-items: center;
   gap: 6px;
   font-size: 1rem;
+  color: #fff;
 }
 
 .charts-area {

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -30,15 +30,21 @@
         </button>
         <div class="sidebar-title-row">
           <h3 class="sidebar-title">Filtros</h3>
-          <button class="sidebar-nav-btn" id="sidebarNavBtn" title="Navegar página" onclick="togglePage()">
-            <span id="sidebarNavIcon">&#8595;</span>
-          </button>
         </div>
+        <button class="sidebar-nav-btn" id="sidebarNavBtn" title="Navegar página" onclick="togglePage()">
+          <span class="nav-arrow"></span>
+        </button>
+      </div>
   <script>
     // Alterna seta do botão de navegação conforme página e faz scroll
     let onTopPage = true;
     function updateSidebarNavIcon(isTop) {
-      document.getElementById('sidebarNavIcon').innerHTML = isTop ? '\u2193' : '\u2191';
+      const btn = document.getElementById('sidebarNavBtn');
+      if (isTop) {
+        btn.classList.remove('up');
+      } else {
+        btn.classList.add('up');
+      }
     }
     function togglePage() {
       const container = document.querySelector('.snap-container');
@@ -53,8 +59,7 @@
     }
     // Inicializa seta para baixo
     updateSidebarNavIcon(true);
-  </script>
-      </div>
+    </script>
       <div class="accordion">
         <div class="accordion-item">
           <button class="accordion-header" type="button">Data</button>


### PR DESCRIPTION
## Summary
- Replace page scroll arrow with minimalist icon on sidebar edge
- Keep hamburger button fixed in place when sidebar opens or closes
- Display UPS and defect filter labels in white

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5fc4401788324b66f2047fa2dcf76