### PR TITLE
Refine sidebar navigation arrow style

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -268,9 +268,6 @@ body {
   align-items: center;
   gap: 6px;
   font-size: 1rem;
-}
-
-.checkbox-label {
   color: #fff;
 }
 
@@ -326,8 +323,8 @@ body {
 
 .sidebar-nav-icon {
   position: relative;
-  width: 14px;
-  height: 14px;
+  width: 16px;
+  height: 16px;
 }
 
 .sidebar-nav-icon::before,
@@ -335,27 +332,30 @@ body {
   content: "";
   position: absolute;
   top: 50%;
-  left: 50%;
-  width: 12px;
-  height: 2px;
+  width: 10px;
+  height: 3px;
   background: #3498db;
   transition: transform 0.2s;
 }
 
 .sidebar-nav-icon::before {
-  transform: translate(-50%, -50%) rotate(45deg);
+  left: 0;
+  transform-origin: left center;
+  transform: translateY(-50%) rotate(45deg);
 }
 
 .sidebar-nav-icon::after {
-  transform: translate(-50%, -50%) rotate(-45deg);
+  right: 0;
+  transform-origin: right center;
+  transform: translateY(-50%) rotate(-45deg);
 }
 
 .sidebar-nav-icon.up::before {
-  transform: translate(-50%, -50%) rotate(-45deg);
+  transform: translateY(-50%) rotate(-45deg);
 }
 
 .sidebar-nav-icon.up::after {
-  transform: translate(-50%, -50%) rotate(45deg);
+  transform: translateY(-50%) rotate(45deg);
 }
 
 .snap-page {

--- a/static/styles.css
+++ b/static/styles.css
@@ -150,6 +150,7 @@ body {
   max-width: 100%;
 }
 
+
 .sidebar {
   width: 320px;
   background: var(--panel-bg);
@@ -157,16 +158,16 @@ body {
   padding: 0 12px 24px;
   overflow-y: auto;
   transition: width .3s;
+  position: relative;
 }
 
 .sidebar.minimized {
   width: 60px;
-  padding: 40px 5px;
+  padding: 0 5px 24px;
 }
 
 /* Esconde todos os textos e controles da sidebar quando minimizada */
 .sidebar.minimized .sidebar-title,
-.sidebar.minimized .sidebar-nav-btn,
 .sidebar.minimized .accordion-header,
 .sidebar.minimized .accordion-content,
 .sidebar.minimized .checkbox-label,
@@ -195,8 +196,9 @@ body {
   color: var(--yellow);
   cursor: pointer;
   position: absolute;
-  top: 50%;
-  transform: translateY(-50%);
+  top: 10px;
+  left: 10px;
+  transform: none;
   z-index: 2;
 }
 
@@ -268,6 +270,10 @@ body {
   font-size: 1rem;
 }
 
+.checkbox-label {
+  color: #fff;
+}
+
 .charts-area {
   flex: 1;
   overflow: auto;
@@ -301,21 +307,55 @@ body {
   position: relative;
 }
 
-/* Botão redondo para navegação entre páginas */
+/* Botão de navegação entre páginas - seta minimalista */
 .sidebar-nav-btn {
   width: 36px;
   height: 36px;
-  border-radius: 50%;
   border: none;
-  background: var(--blue-dark);
-  color: var(--yellow);
+  background: transparent;
   display: flex;
   align-items: center;
   justify-content: center;
-  margin-left: 10px;
-  font-size: 1.75rem;
   cursor: pointer;
-  transition: background 0.2s;
+  position: absolute;
+  top: 50%;
+  right: -12px;
+  transform: translateY(-50%);
+  padding: 0;
+}
+
+.sidebar-nav-icon {
+  position: relative;
+  width: 14px;
+  height: 14px;
+}
+
+.sidebar-nav-icon::before,
+.sidebar-nav-icon::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 12px;
+  height: 2px;
+  background: #3498db;
+  transition: transform 0.2s;
+}
+
+.sidebar-nav-icon::before {
+  transform: translate(-50%, -50%) rotate(45deg);
+}
+
+.sidebar-nav-icon::after {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+.sidebar-nav-icon.up::before {
+  transform: translate(-50%, -50%) rotate(-45deg);
+}
+
+.sidebar-nav-icon.up::after {
+  transform: translate(-50%, -50%) rotate(45deg);
 }
 
 .snap-page {

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -31,15 +31,18 @@
         <div class="sidebar-title-row">
           <h3 class="sidebar-title">Filtros</h3>
           <button class="sidebar-nav-btn" id="sidebarNavBtn" title="Navegar página" onclick="togglePage()">
-            <span id="sidebarNavIcon">&#8595;</span>
+            <span id="sidebarNavIcon" class="sidebar-nav-icon"></span>
           </button>
         </div>
-  <script>
+<script>
     // Alterna seta do botão de navegação conforme página e faz scroll
-    let onTopPage = true;
-    function updateSidebarNavIcon(isTop) {
-      document.getElementById('sidebarNavIcon').innerHTML = isTop ? '\u2193' : '\u2191';
-    }
+      let onTopPage = true;
+      function updateSidebarNavIcon(isTop) {
+        const icon = document.getElementById('sidebarNavIcon');
+        if (icon) {
+          icon.classList.toggle('up', !isTop);
+        }
+      }
     function togglePage() {
       const container = document.querySelector('.snap-container');
       if (onTopPage) {


### PR DESCRIPTION
## Summary
- align page navigation arrow closer to sidebar and vertically centered
- swap to minimalist chevron arrow with hamburger-matching blue

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a5fc4cfb308324a08996cc55251f66