### PR TITLE
feat: refine sidebar navigation

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -195,11 +195,11 @@ body {
   background: transparent;
   color: var(--yellow);
   cursor: pointer;
-  position: absolute;
-  top: 10px;
-  left: 10px;
+  position: fixed;
+  top: 66px;
+  left: 22px;
   transform: none;
-  z-index: 2;
+  z-index: 1000;
 }
 
 .hamburger-bar {
@@ -270,7 +270,8 @@ body {
   font-size: 1rem;
 }
 
-.checkbox-label {
+.checkbox-label,
+.radio-label {
   color: #fff;
 }
 
@@ -324,11 +325,9 @@ body {
 }
 
 .sidebar-nav-icon {
-  width: 0;
-  height: 0;
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-top: 12px solid var(--yellow);
+  width: 24px;
+  height: 24px;
+  color: var(--yellow);
   transition: transform 0.2s;
 }
 

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -31,9 +31,11 @@
         <div class="sidebar-title-row">
           <h3 class="sidebar-title">Filtros</h3>
           <button class="sidebar-nav-btn" id="sidebarNavBtn" title="Navegar página" onclick="togglePage()">
-            <span id="sidebarNavIcon" class="sidebar-nav-icon"></span>
+            <svg id="sidebarNavIcon" class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
           </button>
-        </div>
+          </div>
 <script>
     // Alterna seta do botão de navegação conforme página e faz scroll
       let onTopPage = true;


### PR DESCRIPTION
## Summary
- replace sidebar page navigation arrow with minimal SVG icon
- keep sidebar hamburger toggle fixed onscreen
- ensure filter option labels render in white

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a603272380832495d0f50003afa360