### PR TITLE
Refine sidebar layout and filter order

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -197,7 +197,7 @@ body {
   cursor: pointer;
   position: fixed;
   top: 66px;
-  left: 22px;
+  left: 11px;
   transform: none;
   z-index: 1000;
 }
@@ -320,7 +320,7 @@ body {
   cursor: pointer;
   position: absolute;
   top: 20px;
-  right: -18px;
+  right: 0;
   padding: 0;
 }
 

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -95,21 +95,21 @@
           </div>
         </div>
         <div class="accordion-item">
-          <button class="accordion-header" type="button">Dias de Inspeção</button>
-          <div class="accordion-content">
-            <div class="radio-group">
-              <label class="radio-label"><input type="radio" name="inspectionDays" value="with" checked> Dias com mais de 10 inspeções</label>
-              <label class="radio-label"><input type="radio" name="inspectionDays" value="all"> Incluir dias com menos de 10 inspeções</label>
-            </div>
-          </div>
-        </div>
-        <div class="accordion-item">
           <button class="accordion-header" type="button">Tipo de Defeito</button>
           <div class="accordion-content">
             <div class="checkbox-group">
               <label class="checkbox-label"><input type="checkbox" id="defeito1" checked> Fiação com solda fria</label>
               <label class="checkbox-label"><input type="checkbox" id="defeito2" checked> Respingo de solda</label>
               <label class="checkbox-label"><input type="checkbox" id="defeito3" checked> Curto por solda</label>
+            </div>
+          </div>
+        </div>
+        <div class="accordion-item">
+          <button class="accordion-header" type="button">Dias de Inspeção</button>
+          <div class="accordion-content">
+            <div class="radio-group">
+              <label class="radio-label"><input type="radio" name="inspectionDays" value="with" checked> Dias com mais de 10 inspeções</label>
+              <label class="radio-label"><input type="radio" name="inspectionDays" value="all"> Incluir dias com menos de 10 inspeções</label>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- Repositioned sidebar navigation arrow further left to prevent horizontal scrolling
- Moved "Dias de Inspeção" filter to the end of the list
- Centered hamburger toggle within the collapsed sidebar

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a605103a048324be470fbcdcafb456