### PR TITLE
Use checkbox list for defect type filter

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -30,23 +30,27 @@ document.addEventListener('DOMContentLoaded', () => {
   }
 
   // Atualiza gráficos conforme defeitos selecionados
-  const defectSelect = document.getElementById('defectFilter');
+  const defectContainer = document.getElementById('defectFilter');
   const selectedContainer = document.getElementById('selectedDefectsContainer');
-  if (defectSelect && selectedContainer) {
-    defectSelect.addEventListener('change', () => {
+  if (defectContainer && selectedContainer) {
+    const checkboxes = defectContainer.querySelectorAll('input[type="checkbox"]');
+    function updateSelected() {
       selectedContainer.innerHTML = '';
-      Array.from(defectSelect.selectedOptions).forEach(opt => {
-        const box = document.createElement('div');
-        box.className = 'chart-item chart-small';
-        const title = document.createElement('h4');
-        title.className = 'chart-title';
-        title.textContent = opt.value;
-        box.appendChild(title);
-        const grid = document.createElement('div');
-        grid.className = 'grafico-grid';
-        box.appendChild(grid);
-        selectedContainer.appendChild(box);
+      checkboxes.forEach(cb => {
+        if (cb.checked) {
+          const box = document.createElement('div');
+          box.className = 'chart-item chart-small';
+          const title = document.createElement('h4');
+          title.className = 'chart-title';
+          title.textContent = cb.value;
+          box.appendChild(title);
+          const grid = document.createElement('div');
+          grid.className = 'grafico-grid';
+          box.appendChild(grid);
+          selectedContainer.appendChild(box);
+        }
       });
-    });
+    }
+    checkboxes.forEach(cb => cb.addEventListener('change', updateSelected));
   }
 });

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -97,31 +97,31 @@
         <div class="accordion-item">
           <button class="accordion-header" type="button">Tipo de Defeito</button>
           <div class="accordion-content">
-            <select id="defectFilter" class="filter-select" multiple size="8">
-              <option value="0603 - Fiação com solda fria">0603 - Fiação com solda fria</option>
-              <option value="0002 - Respingo de Solda">0002 - Respingo de Solda</option>
-              <option value="0001 - Curto por Solda">0001 - Curto por Solda</option>
-              <option value="0601 - Fiação invertida">0601 - Fiação invertida</option>
-              <option value="1002 - Outros">1002 - Outros</option>
-              <option value="0802 - Parafuso sem aperto">0802 - Parafuso sem aperto</option>
-              <option value="0401 - Gabinete danificado">0401 - Gabinete danificado</option>
-              <option value="0402 - Gabinete mal encaixado">0402 - Gabinete mal encaixado</option>
-              <option value="0604 - Fiação sem solda">0604 - Fiação sem solda</option>
-              <option value="0003 - Resto de terminal">0003 - Resto de terminal</option>
-              <option value="0502 - Componente danificado">0502 - Componente danificado</option>
-              <option value="0505 - Componente faltando">0505 - Componente faltando</option>
-              <option value="0702 - Abraçadeira faltando">0702 - Abraçadeira faltando</option>
-              <option value="0603 - Componente com solda fria">0603 - Componente com solda fria</option>
-              <option value="1001 - Sem etiqueta">1001 - Sem etiqueta</option>
-              <option value="0201 - Tráfo com barulho">0201 - Tráfo com barulho</option>
-              <option value="0602 - Componente invertido">0602 - Componente invertido</option>
-              <option value="0501 - Fiação danificada">0501 - Fiação danificada</option>
-              <option value="0701 - Amarração errada">0701 - Amarração errada</option>
-              <option value="0803 - Parafuso faltando">0803 - Parafuso faltando</option>
-              <option value="0301 - Bateria danificada">0301 - Bateria danificada</option>
-              <option value="0405 - Botão montado errado">0405 - Botão montado errado</option>
-              <option value="0902 - Cabo Flat invertido">0902 - Cabo Flat invertido</option>
-            </select>
+            <div id="defectFilter" class="checkbox-group">
+              <label class="checkbox-label"><input type="checkbox" value="0603 - Fiação com solda fria"> 0603 - Fiação com solda fria</label>
+              <label class="checkbox-label"><input type="checkbox" value="0002 - Respingo de Solda"> 0002 - Respingo de Solda</label>
+              <label class="checkbox-label"><input type="checkbox" value="0001 - Curto por Solda"> 0001 - Curto por Solda</label>
+              <label class="checkbox-label"><input type="checkbox" value="0601 - Fiação invertida"> 0601 - Fiação invertida</label>
+              <label class="checkbox-label"><input type="checkbox" value="1002 - Outros"> 1002 - Outros</label>
+              <label class="checkbox-label"><input type="checkbox" value="0802 - Parafuso sem aperto"> 0802 - Parafuso sem aperto</label>
+              <label class="checkbox-label"><input type="checkbox" value="0401 - Gabinete danificado"> 0401 - Gabinete danificado</label>
+              <label class="checkbox-label"><input type="checkbox" value="0402 - Gabinete mal encaixado"> 0402 - Gabinete mal encaixado</label>
+              <label class="checkbox-label"><input type="checkbox" value="0604 - Fiação sem solda"> 0604 - Fiação sem solda</label>
+              <label class="checkbox-label"><input type="checkbox" value="0003 - Resto de terminal"> 0003 - Resto de terminal</label>
+              <label class="checkbox-label"><input type="checkbox" value="0502 - Componente danificado"> 0502 - Componente danificado</label>
+              <label class="checkbox-label"><input type="checkbox" value="0505 - Componente faltando"> 0505 - Componente faltando</label>
+              <label class="checkbox-label"><input type="checkbox" value="0702 - Abraçadeira faltando"> 0702 - Abraçadeira faltando</label>
+              <label class="checkbox-label"><input type="checkbox" value="0603 - Componente com solda fria"> 0603 - Componente com solda fria</label>
+              <label class="checkbox-label"><input type="checkbox" value="1001 - Sem etiqueta"> 1001 - Sem etiqueta</label>
+              <label class="checkbox-label"><input type="checkbox" value="0201 - Tráfo com barulho"> 0201 - Tráfo com barulho</label>
+              <label class="checkbox-label"><input type="checkbox" value="0602 - Componente invertido"> 0602 - Componente invertido</label>
+              <label class="checkbox-label"><input type="checkbox" value="0501 - Fiação danificada"> 0501 - Fiação danificada</label>
+              <label class="checkbox-label"><input type="checkbox" value="0701 - Amarração errada"> 0701 - Amarração errada</label>
+              <label class="checkbox-label"><input type="checkbox" value="0803 - Parafuso faltando"> 0803 - Parafuso faltando</label>
+              <label class="checkbox-label"><input type="checkbox" value="0301 - Bateria danificada"> 0301 - Bateria danificada</label>
+              <label class="checkbox-label"><input type="checkbox" value="0405 - Botão montado errado"> 0405 - Botão montado errado</label>
+              <label class="checkbox-label"><input type="checkbox" value="0902 - Cabo Flat invertido"> 0902 - Cabo Flat invertido</label>
+            </div>
           </div>
         </div>
         <div class="accordion-item">


### PR DESCRIPTION
## Summary
- Replace defect type `<select>` with checkbox list allowing multi-select or none
- Update client script to listen to defect checkboxes and display selected charts

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a60be98f988324972e51fc9a22ad68