### PR TITLE
Keep filter open and display selected defects as removable cells

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -33,26 +33,39 @@ document.addEventListener('DOMContentLoaded', () => {
   const defectSelect = document.getElementById('defectFilter');
   const selectedContainer = document.getElementById('selectedDefectsContainer');
   if (defectSelect && selectedContainer) {
-    function updateSelected() {
-      selectedContainer.innerHTML = '';
-      if (defectSelect.value) {
+    const selectedDefects = new Map();
+
+    defectSelect.addEventListener('change', () => {
+      const value = defectSelect.value;
+      if (value && !selectedDefects.has(value)) {
         const box = document.createElement('div');
-        box.className = 'chart-item chart-small';
+        box.className = 'chart-item chart-small selected-defect';
         const title = document.createElement('h4');
         title.className = 'chart-title';
-        title.textContent = defectSelect.value;
+        title.textContent = value;
         box.appendChild(title);
         const grid = document.createElement('div');
         grid.className = 'grafico-grid';
         box.appendChild(grid);
+
+        box.addEventListener('click', () => {
+          selectedContainer.removeChild(box);
+          selectedDefects.delete(value);
+        });
+
         selectedContainer.appendChild(box);
+        selectedDefects.set(value, box);
       }
-    }
-    defectSelect.addEventListener('change', () => {
-      updateSelected();
+
+      defectSelect.value = '';
       const content = defectSelect.closest('.accordion-content');
       if (content) {
         content.classList.remove('open');
+      }
+
+      const sidebar = document.getElementById('sidebar');
+      if (sidebar) {
+        sidebar.classList.remove('minimized');
       }
     });
   }

--- a/static/styles.css
+++ b/static/styles.css
@@ -422,6 +422,11 @@ body {
   height: 100%;
 }
 
+.selected-defect {
+  border: 3px solid var(--yellow);
+  cursor: pointer;
+}
+
 .chart-small {
   flex: 1 1 0;
   width: 100%;


### PR DESCRIPTION
## Summary
- Prevent sidebar from minimizing when choosing a defect and collapse only the defect accordion
- Render each chosen defect as a highlighted cell and allow removal by clicking it

## Testing
- `python -m pytest` *(fails: test_about expected 200 but got 404)*

------
https://chatgpt.com/codex/tasks/task_e_68a61137a4f08324a81f4e37ba65aad8