### PR TITLE
feat: dynamic defect grid layout

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -35,6 +35,48 @@ document.addEventListener('DOMContentLoaded', () => {
   if (defectSelect && selectedContainer) {
     const selectedDefects = new Map();
 
+    function updateLayout() {
+      const items = Array.from(selectedContainer.querySelectorAll('.selected-defect'));
+      const count = items.length;
+
+      if (count === 0) {
+        selectedContainer.style.gridTemplateColumns = '';
+        selectedContainer.style.gridTemplateRows = '';
+        return;
+      }
+
+      let top, bottom;
+      if (count % 2 === 0) {
+        top = bottom = count / 2;
+      } else if (count >= 3) {
+        top = Math.floor(count / 2);
+        bottom = count - top;
+      } else {
+        top = count;
+        bottom = 0;
+      }
+
+      const cols = Math.max(top, bottom);
+      selectedContainer.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
+      selectedContainer.style.gridTemplateRows = bottom > 0 ? '1fr 1fr' : '1fr';
+
+      const placeRow = (startIdx, n, row) => {
+        if (n === 0) return;
+        const baseSpan = Math.floor(cols / n) || 1;
+        let colStart = 1;
+        for (let i = 0; i < n; i++) {
+          const item = items[startIdx + i];
+          const span = i === n - 1 ? cols - colStart + 1 : baseSpan;
+          item.style.gridRow = String(row);
+          item.style.gridColumn = `${colStart} / span ${span}`;
+          colStart += span;
+        }
+      };
+
+      placeRow(0, top, 1);
+      placeRow(top, bottom, 2);
+    }
+
     defectSelect.addEventListener('change', () => {
       const value = defectSelect.value;
       if (value && !selectedDefects.has(value)) {
@@ -51,10 +93,12 @@ document.addEventListener('DOMContentLoaded', () => {
         box.addEventListener('click', () => {
           selectedContainer.removeChild(box);
           selectedDefects.delete(value);
+          updateLayout();
         });
 
         selectedContainer.appendChild(box);
         selectedDefects.set(value, box);
+        updateLayout();
       }
 
       defectSelect.value = '';

--- a/static/styles.css
+++ b/static/styles.css
@@ -411,8 +411,6 @@ body {
 
 .selected-defects-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
-  grid-auto-rows: 1fr;
   gap: 16px;
   width: 100%;
   height: 100%;
@@ -423,7 +421,6 @@ body {
 }
 
 .selected-defect {
-  border: 3px solid var(--yellow);
   cursor: pointer;
 }
 


### PR DESCRIPTION
## Summary
- dynamically compute grid layout for selected defects, splitting charts between rows based on count
- remove rigid layout classes and border styling for a cleaner defect selection grid

## Testing
- ⚠️ `node /tmp/test_layout.js` *(module not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a646257e608324ba103d78cf3ddc55