### PR TITLE
feat: add close buttons for filters and align nav control

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,11 +1,49 @@
 document.addEventListener('DOMContentLoaded', () => {
   const sidebar = document.getElementById('sidebar');
   const hamburgerSidebarBtn = document.getElementById('hamburgerSidebarBtn');
+  const sidebarNavBtn = document.getElementById('sidebarNavBtn');
+  const sidebarNavIcon = document.getElementById('sidebarNavIcon');
+
+  function positionNavBtn() {
+    if (sidebarNavBtn && sidebar) {
+      if (sidebar.classList.contains('minimized')) {
+        sidebarNavBtn.style.left = '12px';
+      } else {
+        sidebarNavBtn.style.left = sidebar.offsetWidth + 'px';
+      }
+    }
+  }
+  positionNavBtn();
+  window.addEventListener('resize', positionNavBtn);
+
   if (hamburgerSidebarBtn) {
     hamburgerSidebarBtn.addEventListener('click', function () {
       sidebar.classList.toggle('minimized');
+      positionNavBtn();
     });
   }
+
+  let onTopPage = true;
+  function updateSidebarNavIcon(isTop) {
+    if (sidebarNavIcon) {
+      sidebarNavIcon.classList.toggle('up', !isTop);
+    }
+  }
+  function togglePage() {
+    const container = document.querySelector('.snap-container');
+    if (onTopPage) {
+      container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+      updateSidebarNavIcon(false);
+    } else {
+      container.scrollTo({ top: 0, behavior: 'smooth' });
+      updateSidebarNavIcon(true);
+    }
+    onTopPage = !onTopPage;
+  }
+  if (sidebarNavBtn) {
+    sidebarNavBtn.addEventListener('click', togglePage);
+  }
+  updateSidebarNavIcon(true);
 
   // Mostrar custom-date-range só se for Personalizado
   const dateSelect = document.getElementById('dateFilter');
@@ -80,6 +118,16 @@ document.addEventListener('DOMContentLoaded', () => {
       if (value && !selectedDefects.has(value)) {
         const box = document.createElement('div');
         box.className = 'chart-item chart-small selected-defect';
+        const closeBtn = document.createElement('button');
+        closeBtn.className = 'selected-defect-close';
+        closeBtn.textContent = '×';
+        closeBtn.addEventListener('click', (e) => {
+          e.stopPropagation();
+          selectedContainer.removeChild(box);
+          selectedDefects.delete(value);
+          updateLayout();
+        });
+        box.appendChild(closeBtn);
         const title = document.createElement('h4');
         title.className = 'chart-title';
         title.textContent = value;
@@ -87,12 +135,6 @@ document.addEventListener('DOMContentLoaded', () => {
         const grid = document.createElement('div');
         grid.className = 'grafico-grid';
         box.appendChild(grid);
-
-        box.addEventListener('click', () => {
-          selectedContainer.removeChild(box);
-          selectedDefects.delete(value);
-          updateLayout();
-        });
 
         selectedContainer.appendChild(box);
         selectedDefects.set(value, box);

--- a/static/styles.css
+++ b/static/styles.css
@@ -133,6 +133,7 @@ body {
 }
 
 .main-content {
+  position: relative;
   flex: 1;
   display: flex;
   overflow: hidden;
@@ -159,7 +160,6 @@ body {
 /* Esconde todos os textos e controles da sidebar quando minimizada */
 
 .sidebar.minimized .sidebar-title,
-.sidebar.minimized .sidebar-nav-btn,
 .sidebar.minimized .accordion-header,
 .sidebar.minimized .accordion-content,
 .sidebar.minimized .checkbox-label,
@@ -288,6 +288,9 @@ body {
 }
 /* Botão de navegação entre páginas - seta minimalista */
 .sidebar-nav-btn {
+  position: absolute;
+  top: 12px;
+  left: 12px;
   width: 36px;
   height: 36px;
   border: none;
@@ -296,7 +299,7 @@ body {
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  margin-left: auto;
+  transition: left 0.3s;
 }
 
 .sidebar-nav-icon {
@@ -416,6 +419,20 @@ body {
 }
 
 .selected-defect {
+  position: relative;
+}
+
+.selected-defect-close {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  width: 16px;
+  height: 16px;
+  border: none;
+  background: transparent;
+  color: var(--yellow);
+  font-size: 14px;
+  line-height: 1;
   cursor: pointer;
 }
 

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -30,34 +30,6 @@
           <span class="hamburger-bar"></span>
         </button>
         <h3 class="sidebar-title">Filtros</h3>
-        <button class="sidebar-nav-btn" id="sidebarNavBtn" title="Navegar página" onclick="togglePage()">
-          <svg id="sidebarNavIcon" class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-        </button>
-        <script>
-    // Alterna seta do botão de navegação conforme página e faz scroll
-      let onTopPage = true;
-      function updateSidebarNavIcon(isTop) {
-        const icon = document.getElementById('sidebarNavIcon');
-        if (icon) {
-          icon.classList.toggle('up', !isTop);
-        }
-      }
-    function togglePage() {
-      const container = document.querySelector('.snap-container');
-      if (onTopPage) {
-        container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
-        updateSidebarNavIcon(false);
-      } else {
-        container.scrollTo({ top: 0, behavior: 'smooth' });
-        updateSidebarNavIcon(true);
-      }
-      onTopPage = !onTopPage;
-    }
-    // Inicializa seta para baixo
-    updateSidebarNavIcon(true);
-  </script>
       </header>
         <div class="accordion" id="filterAccordion">
           <div class="accordion-item">
@@ -147,6 +119,11 @@
           </div>
         </div>
     </aside>
+    <button class="sidebar-nav-btn" id="sidebarNavBtn" title="Navegar página">
+      <svg id="sidebarNavIcon" class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true">
+        <polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+      </svg>
+    </button>
     <div class="snap-container">
       <!-- Página 1: Dashboard -->
       <section class="snap-page">


### PR DESCRIPTION
## Summary
- add dedicated close button to selected defect filters
- relocate page navigation control outside sidebar and ensure it tracks sidebar width, shifting to the top-left when minimized

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a87b2165ec8324abe491d0e5815d61