### PR TITLE
Exibe seta de navegação sempre visível na sidebar

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -163,7 +163,6 @@ body {
 /* Esconde todos os textos e controles da sidebar quando minimizada */
 
 .sidebar.minimized .sidebar-title,
-.sidebar.minimized .sidebar-nav-btn,
 .sidebar.minimized .accordion-header,
 .sidebar.minimized .accordion-content,
 .sidebar.minimized .checkbox-label,
@@ -175,11 +174,16 @@ body {
 
 .sidebar-header {
   display: flex;
-  align-items: center;
-  justify-content: space-between;
+  align-items: flex-start;
   gap: 12px;
   margin: 0;
   position: relative;
+}
+
+.sidebar-buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .sidebar-hamburger-btn {
@@ -300,7 +304,7 @@ body {
   align-items: center;
   justify-content: center;
   cursor: pointer;
-  margin-left: auto;
+  margin: 0;
 }
 
 .sidebar-nav-icon {

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -24,17 +24,19 @@
   <div class="main-content">
     <aside class="sidebar minimized" id="sidebar">
       <header class="sidebar-header">
-        <button id="hamburgerSidebarBtn" class="sidebar-hamburger-btn" title="Abrir/Fechar Sidebar" aria-label="Abrir/Fechar Sidebar">
-          <span class="hamburger-bar"></span>
-          <span class="hamburger-bar"></span>
-          <span class="hamburger-bar"></span>
-        </button>
+        <div class="sidebar-buttons">
+          <button id="hamburgerSidebarBtn" class="sidebar-hamburger-btn" title="Abrir/Fechar Sidebar" aria-label="Abrir/Fechar Sidebar">
+            <span class="hamburger-bar"></span>
+            <span class="hamburger-bar"></span>
+            <span class="hamburger-bar"></span>
+          </button>
+          <button class="sidebar-nav-btn" id="sidebarNavBtn" title="Navegar página" onclick="togglePage()">
+            <svg id="sidebarNavIcon" class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+            </svg>
+          </button>
+        </div>
         <h3 class="sidebar-title">Filtros</h3>
-        <button class="sidebar-nav-btn" id="sidebarNavBtn" title="Navegar página" onclick="togglePage()">
-          <svg id="sidebarNavIcon" class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true">
-            <polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
-          </svg>
-        </button>
         <script>
     // Alterna seta do botão de navegação conforme página e faz scroll
       let onTopPage = true;


### PR DESCRIPTION
## Summary
- Organiza cabeçalho da sidebar para empilhar o botão hamburger e a seta de navegação
- Ajusta estilos para manter a seta visível quando a sidebar está minimizada

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8adc590f48324a1d6a8d3957fa8c9