### PR TITLE
Place page navigation button above defects and across pages

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -296,7 +296,14 @@ body {
   max-width: 100%;
 }
 
-.sidebar-nav-btn {
+.page-nav-container {
+  width: 100%;
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 10px;
+}
+
+.page-nav-btn {
   width: 36px;
   height: 36px;
   border: none;
@@ -308,14 +315,14 @@ body {
   margin: 0;
 }
 
-.sidebar-nav-icon {
+.page-nav-icon {
   width: 24px;
   height: 24px;
   color: #3498db;
   transition: transform 0.2s;
 }
 
-.sidebar-nav-icon.up {
+.page-nav-icon.up {
   transform: rotate(180deg);
 }
 

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -30,36 +30,8 @@
             <span class="hamburger-bar"></span>
             <span class="hamburger-bar"></span>
           </button>
-          <button class="sidebar-nav-btn" id="sidebarNavBtn" title="Navegar página" onclick="togglePage()">
-            <svg id="sidebarNavIcon" class="sidebar-nav-icon" viewBox="0 0 24 24" aria-hidden="true">
-              <polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
-            </svg>
-          </button>
         </div>
         <h3 class="sidebar-title">Filtros</h3>
-        <script>
-    // Alterna seta do botão de navegação conforme página e faz scroll
-      let onTopPage = true;
-      function updateSidebarNavIcon(isTop) {
-        const icon = document.getElementById('sidebarNavIcon');
-        if (icon) {
-          icon.classList.toggle('up', !isTop);
-        }
-      }
-    function togglePage() {
-      const container = document.querySelector('.snap-container');
-      if (onTopPage) {
-        container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
-        updateSidebarNavIcon(false);
-      } else {
-        container.scrollTo({ top: 0, behavior: 'smooth' });
-        updateSidebarNavIcon(true);
-      }
-      onTopPage = !onTopPage;
-    }
-    // Inicializa seta para baixo
-    updateSidebarNavIcon(true);
-  </script>
       </header>
         <div class="accordion" id="filterAccordion">
           <div class="accordion-item">
@@ -153,6 +125,13 @@
       <!-- Página 1: Dashboard -->
       <section class="snap-page">
         <section class="charts-area no-scroll">
+          <div class="page-nav-container">
+            <button class="page-nav-btn" title="Navegar página" onclick="togglePage()">
+              <svg class="page-nav-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </button>
+          </div>
           <div class="charts-grid-custom">
             <div class="chart-item chart-hoje">
               <h4 class="chart-title">DEFEITOS</h4>
@@ -181,6 +160,13 @@
       <!-- Página 2: Conteúdo extra -->
       <section class="snap-page">
         <section class="charts-area no-scroll">
+          <div class="page-nav-container">
+            <button class="page-nav-btn" title="Navegar página" onclick="togglePage()">
+              <svg class="page-nav-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </button>
+          </div>
           <div class="charts-grid-custom">
             <div id="selectedDefectsContainer" class="selected-defects-grid"></div>
           </div>
@@ -195,6 +181,26 @@
       <span id="totalDefects">Defeitos: 20</span>
     </div>
   </footer>
+    <script>
+      let onTopPage = true;
+      function updatePageNavIcon(isTop) {
+        document.querySelectorAll('.page-nav-icon').forEach(icon => {
+          icon.classList.toggle('up', !isTop);
+        });
+      }
+      function togglePage() {
+        const container = document.querySelector('.snap-container');
+        if (onTopPage) {
+          container.scrollTo({ top: container.scrollHeight, behavior: 'smooth' });
+          updatePageNavIcon(false);
+        } else {
+          container.scrollTo({ top: 0, behavior: 'smooth' });
+          updatePageNavIcon(true);
+        }
+        onTopPage = !onTopPage;
+      }
+      updatePageNavIcon(true);
+    </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
     <script src="{{ url_for('static', filename='script.js') }}" defer></script>
   </body>


### PR DESCRIPTION
## Summary
- Move page navigation control to its own row above the centered "DEFEITOS" heading
- Display navigation button on both dashboard pages so it remains available after filtering
- Update script to toggle all navigation icons

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a8bd373ca4832489406bf975848dd6