### PR TITLE
Fix page navigation button layout and visibility

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -299,13 +299,15 @@ body {
 .defects-header {
   display: flex;
   align-items: center;
-  gap: 8px;
+  justify-content: center;
+  position: relative;
   margin-bottom: 10px;
 }
 
 .defects-header .chart-title {
   margin: 0;
-  text-align: left;
+  text-align: center;
+  flex: 1;
 }
 
 .page-nav-btn {
@@ -318,6 +320,8 @@ body {
   justify-content: center;
   cursor: pointer;
   margin: 0;
+  position: absolute;
+  left: 0;
 }
 
 .page-nav-icon {
@@ -429,8 +433,8 @@ body {
   display: grid;
   gap: 16px;
   width: 100%;
-  height: 100%;
-  grid-row: 1 / -1;
+  flex: 1;
+  overflow-y: auto;
 }
 
 .selected-defects-grid .chart-item {

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -128,12 +128,12 @@
           <div class="charts-grid-custom">
             <div class="chart-item chart-hoje">
               <div class="defects-header">
-                <h4 class="chart-title">DEFEITOS</h4>
-                <button class="page-nav-btn" id="pageNavBtn" title="Navegar página" onclick="togglePage()">
-                  <svg id="pageNavIcon" class="page-nav-icon" viewBox="0 0 24 24" aria-hidden="true">
+                <button class="page-nav-btn" title="Navegar página" onclick="togglePage()">
+                  <svg class="page-nav-icon" viewBox="0 0 24 24" aria-hidden="true">
                     <polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
                   </svg>
                 </button>
+                <h4 class="chart-title">DEFEITOS</h4>
               </div>
               <div class="grafico-grid"></div>
             </div>
@@ -161,7 +161,17 @@
       <section class="snap-page">
         <section class="charts-area no-scroll">
           <div class="charts-grid-custom">
-            <div id="selectedDefectsContainer" class="selected-defects-grid"></div>
+            <div class="chart-item chart-hoje">
+              <div class="defects-header">
+                <button class="page-nav-btn" title="Navegar página" onclick="togglePage()">
+                  <svg class="page-nav-icon" viewBox="0 0 24 24" aria-hidden="true">
+                    <polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
+                  </svg>
+                </button>
+                <h4 class="chart-title">DEFEITOS</h4>
+              </div>
+              <div id="selectedDefectsContainer" class="selected-defects-grid"></div>
+            </div>
           </div>
         </section>
       </section>
@@ -177,10 +187,9 @@
     <script>
       let onTopPage = true;
       function updatePageNavIcon(isTop) {
-        const icon = document.getElementById('pageNavIcon');
-        if (icon) {
+        document.querySelectorAll('.page-nav-icon').forEach(icon => {
           icon.classList.toggle('up', !isTop);
-        }
+        });
       }
       function togglePage() {
         const container = document.querySelector('.snap-container');


### PR DESCRIPTION
## Summary
- Center DEFEITOS header and place navigation button before it
- Show page navigation button on second page and update icon toggle

## Testing
- `python -m py_compile app.py && echo "py_compile succeeded"`


------
https://chatgpt.com/codex/tasks/task_e_68a8c66f2da48324950a63e2a56ecaad