### PR TITLE
Fix second page layout and remove redundant heading

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -302,6 +302,7 @@ body {
   justify-content: center;
   position: relative;
   margin-bottom: 10px;
+  min-height: 36px;
 }
 
 .defects-header .chart-title {
@@ -365,6 +366,10 @@ body {
   align-items: stretch;
   justify-items: stretch;
   box-sizing: border-box;
+}
+
+.charts-grid-custom.single-row {
+  grid-template-rows: 1fr;
 }
 
 .chart-item {

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -160,7 +160,7 @@
       <!-- Página 2: Conteúdo extra -->
       <section class="snap-page">
         <section class="charts-area no-scroll">
-          <div class="charts-grid-custom">
+          <div class="charts-grid-custom single-row">
             <div class="chart-item chart-hoje">
               <div class="defects-header">
                 <button class="page-nav-btn" title="Navegar página" onclick="togglePage()">
@@ -168,7 +168,6 @@
                     <polyline points="6 9 12 15 18 9" fill="none" stroke="currentColor" stroke-width="4" stroke-linecap="round" stroke-linejoin="round" />
                   </svg>
                 </button>
-                <h4 class="chart-title">DEFEITOS</h4>
               </div>
               <div id="selectedDefectsContainer" class="selected-defects-grid"></div>
             </div>


### PR DESCRIPTION
## Summary
- Ensure the nav header on the defects page keeps space by adding a minimum height
- Add single-row grid option and apply it to the second page so it occupies full height without 'DEFEITOS' title

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8c8c7bbc483248c9158f4c9469369