### PR TITLE
Add defect ordering controls to sidebar

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -563,3 +563,82 @@ body {
     gap: 16px;
   }
 }
+
+/* Sidebar defect filter additions */
+.sidebar-section-title {
+  color: var(--yellow);
+  font-size: 1rem;
+  margin: 12px 0 8px;
+}
+
+.toggle-switch {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.toggle-switch .order-label {
+  color: var(--text-light);
+  font-size: 0.9rem;
+}
+
+.switch {
+  position: relative;
+  width: 42px;
+  height: 22px;
+}
+
+.switch input {
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.slider {
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: #ccc;
+  transition: .4s;
+  border-radius: 22px;
+}
+
+.slider:before {
+  position: absolute;
+  content: "";
+  height: 18px;
+  width: 18px;
+  left: 2px;
+  bottom: 2px;
+  background-color: #fff;
+  transition: .4s;
+  border-radius: 50%;
+}
+
+.switch input:checked + .slider {
+  background-color: var(--yellow);
+}
+
+.switch input:checked + .slider:before {
+  transform: translateX(20px);
+}
+
+.quantity-container {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.quantity-container label {
+  color: var(--text-light);
+  font-size: 0.9rem;
+}
+
+.quantity-input {
+  width: 80px;
+}

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -90,6 +90,20 @@
             </h2>
             <div id="collapseDefect" class="accordion-collapse collapse" aria-labelledby="headingDefect" data-bs-parent="#filterAccordion">
               <div class="accordion-body">
+                <h5 class="sidebar-section-title">Ordenar defeitos</h5>
+                <div class="toggle-switch">
+                  <span class="order-label">Decrescente</span>
+                  <label class="switch">
+                    <input type="checkbox" id="defectOrderSwitch">
+                    <span class="slider"></span>
+                  </label>
+                  <span class="order-label">Crescente</span>
+                </div>
+                <div class="quantity-container">
+                  <label for="defectQuantity">Quantidade:</label>
+                  <input type="number" id="defectQuantity" class="form-control quantity-input" min="1" value="1">
+                </div>
+                <h5 class="sidebar-section-title">Defeitos Específicos</h5>
                 <select id="defectFilter" class="form-select filter-select">
                   <option value="">Selecione um defeito</option>
                   <option value="0001 - Curto por Solda">0001 - Curto por Solda</option>


### PR DESCRIPTION
## Summary
- add sorting toggle and quantity input above defect selection
- label defect selection section as "Defeitos Específicos"
- style new sidebar controls

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68ad058f4ef8832484d14266b8524980