### PR TITLE
Add database-backed inspection/defect totals

### DIFF
--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -189,8 +189,8 @@
   <footer class="footer">
     <img src="{{ url_for('static', filename='/img/logo_nhs_branca.png') }}" alt="Logo NHS" class="logo-nhs">
     <div class="footer-right">
-      <span id="totalInspections">Inspeções: 95</span>
-      <span id="totalDefects">Defeitos: 20</span>
+      <span id="totalInspections"></span>
+      <span id="totalDefects"></span>
     </div>
   </footer>
     <script>


### PR DESCRIPTION
## Summary
- add SQLAlchemy connection and `/get_counts` endpoint for inspection/error totals with optional filters
- display dynamic totals in footer fetched from backend
- compute date ranges and selected cells on the client to query backend

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pip install sqlalchemy pymysql` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68adf2b20d808324967e2105157a7bbc