### PR TITLE
Load defects from backend endpoint

### DIFF
--- a/app.py
+++ b/app.py
@@ -60,5 +60,22 @@ def get_counts():
     except Exception as e:
         return jsonify({'success': False, 'message': str(e)}), 500
 
+
+@app.route('/get_errors', methods=['GET'])
+def get_errors():
+    try:
+        query = """
+            SELECT cod, name
+            FROM error
+            WHERE delete_user_id IS NULL
+            ORDER BY cod
+        """
+        with engine.connect() as conn:
+            result = conn.execute(text(query)).mappings().all()
+        errors = [{'id': row['cod'], 'name': row['name']} for row in result]
+        return jsonify({'success': True, 'errors': errors})
+    except Exception as e:
+        return jsonify({'success': False, 'message': str(e)}), 500
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/static/script.js
+++ b/static/script.js
@@ -117,6 +117,23 @@ document.addEventListener('DOMContentLoaded', () => {
   const selectedContainer = document.getElementById('selectedDefectsContainer');
   const sidebarList = document.getElementById('selectedDefectsSidebar');
   const clearAllBtn = document.getElementById('clearDefectsBtn');
+
+  if (defectSelect) {
+    fetch('/get_errors')
+      .then((r) => r.json())
+      .then((data) => {
+        if (data.success) {
+          data.errors.forEach((err) => {
+            const option = document.createElement('option');
+            const text = `${err.id} - ${err.name}`;
+            option.value = text;
+            option.textContent = text;
+            defectSelect.appendChild(option);
+          });
+        }
+      });
+  }
+
   if (defectSelect && selectedContainer && sidebarList && clearAllBtn) {
     const selectedDefects = new Map();
 

--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -100,29 +100,6 @@
                 <h5 class="sidebar-section-title">Defeitos Específicos</h5>
                 <select id="defectFilter" class="form-select filter-select">
                   <option value="">Selecione um defeito</option>
-                  <option value="0001 - Curto por Solda">0001 - Curto por Solda</option>
-                  <option value="0002 - Respingo de Solda">0002 - Respingo de Solda</option>
-                  <option value="0003 - Resto de terminal">0003 - Resto de terminal</option>
-                  <option value="0201 - Tráfo com barulho">0201 - Tráfo com barulho</option>
-                  <option value="0301 - Bateria danificada">0301 - Bateria danificada</option>
-                  <option value="0401 - Gabinete danificado">0401 - Gabinete danificado</option>
-                  <option value="0402 - Gabinete mal encaixado">0402 - Gabinete mal encaixado</option>
-                  <option value="0405 - Botão montado errado">0405 - Botão montado errado</option>
-                  <option value="0501 - Fiação danificada">0501 - Fiação danificada</option>
-                  <option value="0502 - Componente danificado">0502 - Componente danificado</option>
-                  <option value="0505 - Componente faltando">0505 - Componente faltando</option>
-                  <option value="0601 - Fiação invertida">0601 - Fiação invertida</option>
-                  <option value="0602 - Componente invertido">0602 - Componente invertido</option>
-                  <option value="0603 - Fiação com solda fria">0603 - Fiação com solda fria</option>
-                  <option value="0603 - Componente com solda fria">0603 - Componente com solda fria</option>
-                  <option value="0604 - Fiação sem solda">0604 - Fiação sem solda</option>
-                  <option value="0701 - Amarração errada">0701 - Amarração errada</option>
-                  <option value="0702 - Abraçadeira faltando">0702 - Abraçadeira faltando</option>
-                  <option value="0802 - Parafuso sem aperto">0802 - Parafuso sem aperto</option>
-                  <option value="0803 - Parafuso faltando">0803 - Parafuso faltando</option>
-                  <option value="0902 - Cabo Flat invertido">0902 - Cabo Flat invertido</option>
-                  <option value="1001 - Sem etiqueta">1001 - Sem etiqueta</option>
-                  <option value="1002 - Outros">1002 - Outros</option>
                 </select>
                 <button id="clearDefectsBtn" class="btn btn-warning btn-sm mt-2 w-100" style="display:none;">Limpar Todos</button>
                 <div id="selectedDefectsSidebar" class="selected-defects-sidebar"></div>


### PR DESCRIPTION
## Summary
- fetch defect options via new `/get_errors` endpoint
- serve defects from database instead of hardcoded list

## Testing
- `python -m py_compile app.py`
- `node --check static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68ae01faf9f48324b76330441fc87b2c