### PR TITLE
feat: add dynamic defect ordering and top lists

### DIFF
--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -93,9 +93,10 @@
                   </label>
                   <span class="order-label">Crescente</span>
                 </div>
-                <div class="quantity-container">
-                  <label for="defectQuantity">Quantidade:</label>
-                  <input type="number" id="defectQuantity" class="form-control quantity-input" min="1" value="6">
+                <div class="quantity-container d-flex align-items-center">
+                  <label for="defectQuantity" class="me-2">Quantidade:</label>
+                  <input type="number" id="defectQuantity" class="form-control quantity-input me-2" min="1" value="6">
+                  <button id="defectQuantityOk" class="btn btn-warning btn-sm">OK</button>
                 </div>
                 <h5 class="sidebar-section-title">Defeitos Específicos</h5>
                 <select id="defectFilter" class="form-select filter-select">
@@ -128,15 +129,15 @@
               <div class="top3-title">TOP 3 DEFEITOS</div>
               <div class="top3-row">
                 <div class="chart-item chart-small">
-                  <h4 class="chart-title">0603 - Fiação com solda fria</h4>
+                  <h4 class="chart-title" id="topDefect1">-</h4>
                   <div class="grafico-grid"></div>
                 </div>
                 <div class="chart-item chart-small">
-                  <h4 class="chart-title">0002 - Respingo de Solda</h4>
+                  <h4 class="chart-title" id="topDefect2">-</h4>
                   <div class="grafico-grid"></div>
                 </div>
                 <div class="chart-item chart-small">
-                  <h4 class="chart-title">0001 - Curto por Solda</h4>
+                  <h4 class="chart-title" id="topDefect3">-</h4>
                   <div class="grafico-grid"></div>
                 </div>
               </div>


### PR DESCRIPTION
## Summary
- add backend route to fetch top defects respecting filters
- show top 3 defects dynamically and support ordering with quantity controls
- allow replacing top defects with specific selections

## Testing
- `python -m py_compile app.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68ae057a035483249acea3aad18660fc