### PR TITLE
feat: show defect names and counts in top lists

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -192,7 +192,9 @@ document.addEventListener('DOMContentLoaded', () => {
             const title = topDefectTitles[i];
             if (!title) continue;
             const defect = data.defects[i];
-            title.textContent = defect ? `${defect.id} - ${defect.name}` : '';
+            title.textContent = defect
+              ? `${defect.id} - ${defect.name} (${defect.total})`
+              : '-';
           }
         }
       });
@@ -210,13 +212,16 @@ document.addEventListener('DOMContentLoaded', () => {
           data.defects.forEach((def) => {
             const box = document.createElement('div');
             box.className = 'chart-item chart-small';
+
             const title = document.createElement('h4');
             title.className = 'chart-title';
-            title.textContent = `${def.id} - ${def.name}`;
+            title.textContent = `${def.id} - ${def.name} (${def.total})`;
             box.appendChild(title);
+
             const grid = document.createElement('div');
             grid.className = 'grafico-grid';
             box.appendChild(grid);
+
             selectedContainer.appendChild(box);
           });
           updateLayout();


### PR DESCRIPTION
## Summary
- display defect names and counts in Top 3 section
- show quantity per defect when listing top defects

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae07b5dcd083249cf261f7343b06fe