### PR TITLE
Fix top defects query join

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,7 +94,7 @@ def get_top_defects():
         SELECT e.cod AS id, e.name AS name, COUNT(*) AS total
         FROM sample_inspection si
         JOIN sample_inspection_error sie ON si.id = sie.sample_inspection_id
-        JOIN error e ON sie.error_id = e.cod
+        JOIN error e ON sie.error_id = e.id
         WHERE si.audit = 0 AND DATE(si.ts) BETWEEN :start AND :end
         """
     )


### PR DESCRIPTION
## Summary
- correct join for top defects query to use `error.id`

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae0b52611c83249461a27b44754933