### PR TITLE
Render U-chart data on dashboard

### DIFF
--- a/templates/dashboard_cep.html
+++ b/templates/dashboard_cep.html
@@ -192,6 +192,7 @@
       updatePageNavIcon(true);
     </script>
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="{{ url_for('static', filename='script.js') }}" defer></script>
   </body>
   </html>


### PR DESCRIPTION
## Summary
- load Chart.js for graphing
- add renderUChart function to fetch `/get_u_chart` metrics and draw charts
- refresh dashboards to render overall and defect-specific U-charts

## Testing
- `node --check static/script.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae38348b14832482d98fb8f355b8f3