### PR TITLE
Improve chart readability with light backgrounds

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -31,10 +31,14 @@ document.addEventListener('DOMContentLoaded', () => {
     let end;
     switch (dateSelect.value) {
       case 'today':
-        start = end = today;
+        // Include the four previous days so the chart has context
+        end = today;
+        start = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 4);
         break;
       case 'yesterday':
-        start = end = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1);
+        // Show five consecutive days ending yesterday
+        end = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 1);
+        start = new Date(end.getFullYear(), end.getMonth(), end.getDate() - 4);
         break;
       case 'last3':
         start = new Date(today.getFullYear(), today.getMonth(), today.getDate() - 2);

--- a/static/styles.css
+++ b/static/styles.css
@@ -42,7 +42,7 @@
   --blue-dark: #023275;
   --blue-hover: #04234d;
   --panel-bg: #0048aa;
-  --body-bg: #022961;
+  --body-bg: #f0f0f0;
   --text-light: #ecf0f1;
   --grafico-box-border: #8fd6ff;
 }
@@ -377,7 +377,7 @@ body {
 }
 
 .chart-item {
-  background: var(--panel-bg);
+  background: #ffffff;
   border-radius: 12px;
   box-shadow: 0 2px 8px rgba(0,0,0,0.1);
   padding: 18px 18px 10px;
@@ -389,7 +389,7 @@ body {
 .chart-hoje {
   grid-column: 1 / 2;
   grid-row: 1 / 2;
-  background: var(--panel-bg);
+  background: #ffffff;
   border-radius: 0;
   box-shadow: none;
   padding: 0;
@@ -411,7 +411,7 @@ body {
   flex-direction: column;
   align-items: stretch;
   justify-content: stretch;
-  background: var(--panel-bg);
+  background: #ffffff;
   border-radius: 0;
   box-shadow: none;
   padding: 0;


### PR DESCRIPTION
## Summary
- Use a light page and chart background for better visibility
- Expand single-day selections to show a five-day range for context

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae42eac62c8324bd3d3c6012ab79e1