### PR TITLE
Improve chart interval granularity and sidebar layout

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -7,7 +7,7 @@
   width: 100%;
   height: 100%;
   min-height: 120px;
-  border: 3px solid #8fd6ff;
+  border: 3px solid #0048aa;
   border-radius: 12px;
   background: #ffffff;
   margin: 0 auto;
@@ -253,6 +253,12 @@ body {
   padding: 6px;
   border-radius: 4px;
   border: 1px solid #ccc;
+}
+
+.custom-date-range .date-input {
+  flex: 1 1 0;
+  min-width: 0;
+  width: auto;
 }
 
 .custom-date-range {


### PR DESCRIPTION
## Summary
- Adjust `get_u_chart` to group data by 30 minutes, 8 hours, daily or biweekly depending on range
- Style updates: fix custom date range inputs and use blue borders around charts

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae5093f3308324be1d19b614cd4132