### PR TITLE
Improve u-chart scaling and rendering

### DIFF
--- a/app.py
+++ b/app.py
@@ -204,7 +204,7 @@ def get_u_chart():
     if delta_days <= 1:
         bucket = "FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(si.ts)/1800)*1800)"
     elif delta_days <= 7:
-        bucket = "FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(si.ts)/28800)*28800)"
+        bucket = "FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(si.ts)/14400)*14400)"
     elif delta_days > 92:
         bucket = "DATE_ADD(:start, INTERVAL FLOOR(DATEDIFF(DATE(si.ts), :start)/14)*14 DAY)"
     else:

--- a/static/script.js
+++ b/static/script.js
@@ -202,6 +202,8 @@ document.addEventListener('DOMContentLoaded', () => {
         const uData = data.data.map((d) => d.u);
         const uclData = data.data.map((d) => d.ucl);
         const lclData = data.data.map((d) => d.lcl);
+        const maxValue = Math.max(...uData, ...uclData, 0.5);
+        const yMax = Math.ceil(maxValue / 0.5) * 0.5;
         if (container._chart) {
           container._chart.destroy();
         }
@@ -239,7 +241,9 @@ document.addEventListener('DOMContentLoaded', () => {
                 offset: true,
               },
               y: {
-                ticks: { stepSize: 5 },
+                min: 0,
+                max: yMax,
+                ticks: { stepSize: 0.5 },
               },
             },
           },
@@ -498,7 +502,7 @@ document.addEventListener('DOMContentLoaded', () => {
           selectedDefects.set(id, { box, item, name });
           updateLayout();
           updateSidebarVisibility();
-          updateSelectedDefectCounts().then(updateLastUpdate);
+          Promise.all([renderUChart(grid, id), updateSelectedDefectCounts()]).then(updateLastUpdate);
         }
       }
 


### PR DESCRIPTION
## Summary
- Scale U-chart y-axis in 0.5 increments with dynamic max
- Render charts immediately when selecting specific defects
- Group U-chart data in 4-hour buckets for week-long ranges

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68ae547904c083248ac52a789eba989f