### PR TITLE
Adjust u-chart time buckets for short date ranges

### DIFF
--- a/app.py
+++ b/app.py
@@ -201,10 +201,10 @@ def get_u_chart():
         params['error_cod'] = error_cod
 
     delta_days = (end_date - start_date).days
-    if delta_days <= 1:
+    if delta_days <= 3:
         bucket = "FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(si.ts)/1800)*1800)"
     elif delta_days <= 7:
-        bucket = "FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(si.ts)/14400)*14400)"
+        bucket = "FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(si.ts)/7200)*7200)"
     elif delta_days > 92:
         bucket = "DATE_ADD(:start, INTERVAL FLOOR(DATEDIFF(DATE(si.ts), :start)/14)*14 DAY)"
     else:


### PR DESCRIPTION
## Summary
- use 30-minute buckets for date ranges up to 3 days
- use 2-hour buckets for ranges between 3 and 7 days

## Testing
- `python -m py_compile app.py flask-template/app.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68ae59715c3c8324b69d0e8136ae5698