### PR TITLE
Fix year range filters for current and previous year

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -76,7 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
         break;
       case 'currentYear':
         start = new Date(today.getFullYear(), 0, 1);
-        end = today;
+        end = new Date(today.getFullYear(), 11, 31);
         break;
       case 'previousYear':
         start = new Date(today.getFullYear() - 1, 0, 1);


### PR DESCRIPTION
## Summary
- Ensure `Ano Atual` covers entire calendar year by setting end date to December 31

## Testing
- `node --check static/script.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae61abfb148324b1c80754a45d4a39