### PR TITLE
Adiciona intervalos quinzenais nos filtros anuais

### DIFF
--- a/app.py
+++ b/app.py
@@ -201,12 +201,19 @@ def get_u_chart():
         params['error_cod'] = error_cod
 
     delta_days = (end_date - start_date).days
-    if delta_days <= 3:
+    bucket_param = request.args.get('bucket')
+    if bucket_param == 'biweekly':
+        bucket = (
+            "DATE_ADD(:start, INTERVAL FLOOR(DATEDIFF(DATE(si.ts), :start)/14)*14 DAY)"
+        )
+    elif delta_days <= 3:
         bucket = "FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(si.ts)/1800)*1800)"
     elif delta_days <= 7:
         bucket = "FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(si.ts)/7200)*7200)"
     elif delta_days > 92:
-        bucket = "DATE_ADD(:start, INTERVAL FLOOR(DATEDIFF(DATE(si.ts), :start)/14)*14 DAY)"
+        bucket = (
+            "DATE_ADD(:start, INTERVAL FLOOR(DATEDIFF(DATE(si.ts), :start)/14)*14 DAY)"
+        )
     else:
         bucket = "DATE(si.ts)"
 

--- a/static/script.js
+++ b/static/script.js
@@ -76,7 +76,7 @@ document.addEventListener('DOMContentLoaded', () => {
         break;
       case 'currentYear':
         start = new Date(today.getFullYear(), 0, 1);
-        end = new Date(today.getFullYear(), 11, 31);
+        end = today;
         break;
       case 'previousYear':
         start = new Date(today.getFullYear() - 1, 0, 1);
@@ -186,7 +186,14 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function buildParams(extra = {}) {
     const { start, end } = getDateRange();
-    const params = new URLSearchParams({ start, end, ...extra });
+    const paramsObj = { start, end, ...extra };
+    if (
+      dateSelect &&
+      (dateSelect.value === 'currentYear' || dateSelect.value === 'previousYear')
+    ) {
+      paramsObj.bucket = 'biweekly';
+    }
+    const params = new URLSearchParams(paramsObj);
     selectedCells.forEach((_, cell) => params.append('cell', cell));
     return params;
   }


### PR DESCRIPTION
## Summary
- garante que filtros de ano atual e anterior usem data final correta e gerem buckets quinzenais
- permite forçar o agrupamento em quinzenas na API `/get_u_chart`

## Testing
- `pytest` *(falhou: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_68ae630843f88324a3e324b0324c530a