### PR TITLE
Handle string dates in U-chart generation

### DIFF
--- a/app.py
+++ b/app.py
@@ -276,7 +276,7 @@ def get_u_chart():
         ucl = u_bar + 3 * sigma
         lcl = max(0.0, u_bar - 3 * sigma)
         data.append({
-            'date': dt.isoformat(),
+            'date': dt if isinstance(dt, str) else dt.isoformat(),
             'u': round(u, 4),
             'ucl': round(ucl, 4),
             'lcl': round(lcl, 4),


### PR DESCRIPTION
## Summary
- fix U-chart API to accept string date keys returned by database

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ae6506b9208324a286a2ca89bd9b2c