### PR TITLE
fix defect chart y-axis rounding

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -257,8 +257,12 @@ document.addEventListener('DOMContentLoaded', () => {
               y: {
                 min: 0,
                 max: yMax,
+                grid: {
+                  drawBorder: false,
+                },
                 ticks: {
                   stepSize: step,
+                  precision: 2,
                   callback: (value) => Number(value).toFixed(2),
                 },
               },


### PR DESCRIPTION
## Summary
- prevent rounding of 0.25 step on defect charts by setting tick precision
- display lower control limit line by removing axis border

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68ae69cc37f88324a56779ce65990202