### PR TITLE
Improve defect grid layout and odd-item emphasis

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -147,22 +147,21 @@ document.addEventListener('DOMContentLoaded', () => {
     const items = Array.from(selectedContainer.querySelectorAll('.chart-item'));
     const count = items.length;
 
-    // Clear any manual positioning from a previous layout
+    // Reset manual positioning from previous layouts
     items.forEach((item) => {
       item.style.gridRow = '';
       item.style.gridColumn = '';
     });
 
-    if (count === 0) {
-      selectedContainer.style.gridTemplateColumns = '';
-      selectedContainer.style.gridAutoRows = '';
-      return;
-    }
+    if (count === 0) return;
 
-    // Use at most two rows and let CSS Grid handle item placement
-    const cols = Math.ceil(count / 2);
-    selectedContainer.style.gridTemplateColumns = `repeat(${cols}, 1fr)`;
-    selectedContainer.style.gridAutoRows = 'auto';
+    // Allow CSS to handle column distribution
+    selectedContainer.style.gridTemplateColumns = '';
+
+    // If we have an odd number of charts, make the first span two columns
+    if (count % 2 === 1 && count > 1) {
+      items[0].style.gridColumn = 'span 2';
+    }
   }
 
   function buildParams(extra = {}) {

--- a/static/styles.css
+++ b/static/styles.css
@@ -447,7 +447,8 @@ body {
 
 .selected-defects-grid {
   display: grid;
-  gap: 16px;
+  gap: 24px;
+  grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
   width: 100%;
   flex: 1;
   overflow-y: auto;


### PR DESCRIPTION
## Summary
- Expand selected defects grid to use full screen width with automatic columns and spacing
- Highlight first defect by doubling its width when the number of defects is odd

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68af6c022dbc83248a494de89b941c16