### PR TITLE
Use 15-minute buckets for single-day ranges

### DIFF
--- a/app.py
+++ b/app.py
@@ -201,7 +201,9 @@ def get_u_chart():
         params['error_cod'] = error_cod
 
     delta_days = (end_date - start_date).days
-    if delta_days <= 3:
+    if delta_days <= 1:
+        bucket = "FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(si.ts)/900)*900)"
+    elif delta_days <= 3:
         bucket = "FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(si.ts)/1800)*1800)"
     elif delta_days <= 7:
         bucket = "FROM_UNIXTIME(FLOOR(UNIX_TIMESTAMP(si.ts)/7200)*7200)"


### PR DESCRIPTION
## Summary
- Show 15-minute resolution for graph data when filtering a single day

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68af84ad4fec8324a4802440cc5f06fb