### PR TITLE
Hide default midnight time on daily-only filters

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -24,9 +24,15 @@ document.addEventListener('DOMContentLoaded', () => {
       [datePart, timePart] = str.split(' ');
     }
     const [year, month, day] = datePart.split('-').map(Number);
-    const [hours = 0, minutes = 0, seconds = 0] = timePart.split(':').map(Number);
+    const [hours = 0, minutes = 0, seconds = 0] = timePart
+      .split(':')
+      .map(Number);
     const pad = (n) => String(n).padStart(2, '0');
-    return `${pad(day)}/${pad(month)}/${year} ${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
+    const dateFormatted = `${pad(day)}/${pad(month)}/${year}`;
+    if (hours === 0 && minutes === 0 && seconds === 0) {
+      return dateFormatted;
+    }
+    return `${dateFormatted} ${pad(hours)}:${pad(minutes)}:${pad(seconds)}`;
   };
 
   function toggleCustomRange() {


### PR DESCRIPTION
## Summary
- Do not display `00:00:00` in formatted dates when time part is midnight

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'app')*


------
https://chatgpt.com/codex/tasks/task_e_68af936b38dc8324a73327dce47051dc