### PR TITLE
Persist chart state and preload top defects without auto navigation

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -300,8 +300,11 @@ document.addEventListener('DOMContentLoaded', () => {
         const uclData = data.data.map((d) => d.ucl);
         const lclData = data.data.map((d) => d.lcl);
         const latest = data.data[data.data.length - 1];
-        const prevDate = container.dataset.lastDate;
+        const key = errorId ? `lastDate_${errorId}` : 'lastDate_main';
+        const prevDate =
+          container.dataset.lastDate || localStorage.getItem(key);
         container.dataset.lastDate = latest.date;
+        localStorage.setItem(key, latest.date);
         const isNewPoint = prevDate !== latest.date;
         const outOfControl = latest.u > latest.ucl || latest.u < latest.lcl;
         if (isNewPoint && outOfControl) {
@@ -731,6 +734,10 @@ document.addEventListener('DOMContentLoaded', () => {
 
   if (updateNowBtn) updateNowBtn.addEventListener('click', refreshAndUpdate);
 
-  refreshAndUpdate();
+  if (defectQuantityOk) {
+    defectQuantityOk.click();
+  } else {
+    refreshAndUpdate();
+  }
   setInterval(refreshAndUpdate, 5 * 60 * 1000);
 });


### PR DESCRIPTION
## Summary
- Persist last point date per chart via localStorage so red blinking border only triggers on new out-of-control points and stops after refreshes or updates
- Preload Top 6 defects on second screen while keeping initial view on the first screen

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68b091301db4832492af945e8f71088b